### PR TITLE
Allow user interaction while fading Toast view

### DIFF
--- a/ALToastView.m
+++ b/ALToastView.m
@@ -126,7 +126,8 @@ static NSMutableArray *toasts;
 
 - (void)fadeToastOut {
 	// Fade in parent view
-  [UIView animateWithDuration:.3 
+  [UIView animateWithDuration:0.3 delay:0 options:UIViewAnimationOptionAllowUserInteraction
+   
                    animations:^{
                      self.alpha = 0.f;
                    } 
@@ -152,9 +153,10 @@ static NSMutableArray *toasts;
     
 		// Fade into parent view
 		[parentView addSubview:view];
-    [UIView animateWithDuration:.5 animations:^{
+    [UIView animateWithDuration:.5  delay:0 options:UIViewAnimationOptionAllowUserInteraction
+                     animations:^{
       view.alpha = 1.0;
-    }];
+                     } completion:^(BOOL finished){}];
     
     // Start timer for fade out
     [view performSelector:@selector(fadeToastOut) withObject:nil afterDelay:kDuration];


### PR DESCRIPTION
Added animation option UIViewAnimationOptionAllowUserInteraction to enable user interaction with the parent view while the Toast view is fading in or out.

This is required when using the Toast as a message in a scrollable view like MKMapView. Without this animation option, the map view freezes while the toast view is animating the fade effect, and the user's touch events are lost.
