### PR TITLE
Allow user interaction while animating

### DIFF
--- a/ALToastView.m
+++ b/ALToastView.m
@@ -126,7 +126,8 @@ static NSMutableArray *toasts;
 
 - (void)fadeToastOut {
 	// Fade in parent view
-  [UIView animateWithDuration:.3 
+  [UIView animateWithDuration:0.3 delay:0 options:UIViewAnimationOptionAllowUserInteraction
+   
                    animations:^{
                      self.alpha = 0.f;
                    } 
@@ -152,9 +153,10 @@ static NSMutableArray *toasts;
     
 		// Fade into parent view
 		[parentView addSubview:view];
-    [UIView animateWithDuration:.5 animations:^{
+    [UIView animateWithDuration:.5  delay:0 options:UIViewAnimationOptionAllowUserInteraction
+                     animations:^{
       view.alpha = 1.0;
-    }];
+                     } completion:^(BOOL finished){}];
     
     // Start timer for fade out
     [view performSelector:@selector(fadeToastOut) withObject:nil afterDelay:kDuration];


### PR DESCRIPTION
Added UIViewAnimationOptionAllowUserInteraction animation option to fade animations of Toast View.

This allows panning, scroll and other interactions with the superview while the Toast is fading in or out. Without this animation option, if the Toast is used on a MKMapView or other scroll/pan views, the superview freezes; the user's touches are lost.

(Apologies for the earlier false email notification for the deleted pull request - I made a mistake in that one and had to redo it)
